### PR TITLE
Update to Minecraft 1.20.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,9 +30,9 @@ dependencies {
 	mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
 	modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_api_version}"
-	modImplementation "fi.dy.masa.malilib:malilib-fabric-1.20.2:${project.malilib_version}"
+	modImplementation "fi.dy.masa.malilib:malilib-fabric-1.20.4:${project.malilib_version}"
 	//modImplementation "com.github.DarkKronicle:AdvancedChatCore:${project.advancedchat_version}"
-	modImplementation "io.github.darkkronicle:AdvancedChatCore:1.20.2-1.5.10" // only used to build the mod locally
+	modImplementation "io.github.darkkronicle:AdvancedChatCore:1.20.4-1.5.10" // only used to build the mod locally
 
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,13 +1,13 @@
-minecraft_version=1.20.2
-yarn_mappings=1.20.2+build.4
-loader_version=0.14.24
-fabric_api_version=0.90.4+1.20.2
+minecraft_version=1.20.4
+yarn_mappings=1.20.4+build.3
+loader_version=0.15.3
+fabric_api_version=0.92.0+1.20.4
 
 mod_version=1.3.8
 maven_group=io.github.darkkronicle
 archives_base_name=AdvancedChatHUD
 
-malilib_version = 0.17.0
+malilib_version = 0.18.0
 org.gradle.jvmargs=-Xmx1G
 advancedchat_version=v1.5.10
 


### PR DESCRIPTION
Thanks again for your port to 1.20/1.20.1 and 1.20.2.
This PR ports the mod to 1.20.4.

Related PRs:
- https://github.com/medisant/AdvancedChatCore/pull/1
- https://github.com/medisant/AdvancedChatFilters/pull/1